### PR TITLE
Demo: difftron delta-coverage gate

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: yarn
 
       - run: yarn install --frozen-lockfile

--- a/src/difftronDemo.test.ts
+++ b/src/difftronDemo.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { covered } from './difftronDemo';
+
+describe('difftronDemo', () => {
+  it('covers covered()', () => {
+    expect(covered(2, 3)).toBe(5);
+  });
+});

--- a/src/difftronDemo.ts
+++ b/src/difftronDemo.ts
@@ -1,0 +1,15 @@
+// Throwaway sample used to demonstrate difftron's delta-coverage gate on a
+// pull request. Safe to delete.
+
+// covered is exercised by the co-located test, so its changed lines report as covered.
+export function covered(a: number, b: number): number {
+  return a + b;
+}
+
+// uncovered has no test, so difftron should flag these changed lines as uncovered.
+export function uncovered(a: number, b: number): number {
+  if (a > b) {
+    return a - b;
+  }
+  return b - a;
+}


### PR DESCRIPTION
Throwaway PR to watch the difftron delta-coverage gate run. `src/difftronDemo.ts` has a tested `covered()` and an untested `uncovered()`. Safe to close.